### PR TITLE
Revert field name and restore original config format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Configuration field `discovery.root` reverted back to `discovery.root_path`.
+- Configuration element order restored to original (root_path, cache_ttl_hours).
+- Removed unnecessary quotes from configuration file string values.
+
 ## [1.0.0] - 2026-04-27
 
 ### Added

--- a/src/mr_manager/core/user_config.py
+++ b/src/mr_manager/core/user_config.py
@@ -133,13 +133,8 @@ def load_user_config(config_path: Path | None = None) -> UserConfig:
     parsed_values = _parse_user_config_yaml(resolved_config_path.read_text(encoding="utf-8"))
     return UserConfig(
         discovery_cache_ttl_hours=_resolve_cache_ttl_hours(parsed_values),
-        discovery_root=_validate_discovery_root(parsed_values.get("discovery.root")),
+        discovery_root=_validate_discovery_root(parsed_values.get("discovery.root_path")),
     )
-
-
-def _single_quote_yaml_string(value: str) -> str:
-    """Return a single-quoted YAML scalar string."""
-    return "'" + value.replace("'", "''") + "'"
 
 
 def save_user_config(config: UserConfig, config_path: Path | None = None) -> None:
@@ -160,9 +155,7 @@ def save_user_config(config: UserConfig, config_path: Path | None = None) -> Non
     discovery_root = _validate_discovery_root(str(config.discovery_root))
     resolved_config_path = config_path or get_user_config_path()
     config_text = (
-        "discovery:\n"
-        f"  cache_ttl_hours: {ttl_hours}\n"
-        f"  root: {_single_quote_yaml_string(discovery_root.as_posix())}\n"
+        f"discovery:\n  root_path: {discovery_root.as_posix()}\n  cache_ttl_hours: {ttl_hours}\n"
     )
     resolved_config_path.parent.mkdir(parents=True, exist_ok=True)
     resolved_config_path.write_text(config_text, encoding="utf-8")


### PR DESCRIPTION
## Related Issue

Closes #64 

## Changes

- Rename 'discovery.root' back to 'discovery.root_path'
- Restore original config element order (root_path first, cache_ttl_hours second)
- Remove unnecessary single quotes from path values

## How to Test

- Checkout new version
- Run `mr-manager` and save unchanged configs in editor
- See old config style

## Checklist

Either tick the items or cross out those that do not apply (using ~~example text~~) and provide a brief explanation why they do not apply.

### Author

- [x] I linked the issue that this PR closes.
- [x] I tested the changes locally.
- [ ] I updated the documentation (if needed).
- [ ] I added/updated tests (if needed).
